### PR TITLE
bump prysmaticlabs/prysm to v1.0.5

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,13 +1,13 @@
 {
   "name": "prysm-pyrmont.dnp.dappnode.eth",
   "version": "0.1.5",
-  "upstreamVersion": "v1.0.2",
+  "upstreamVersion": "v1.0.5",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm pyrmont ETH2.0 Beacon chain + validator",
   "description": "Validate with prysm: a Go implementation of the Ethereum 2.0 Serenity protocol and open source project created by Prysmatic Labs. Beacon node which powers the beacon chain at the core of Ethereum 2.0\n\nIt includes a Grafana dashboard for the [DMS](http://my.dappnode/#/installer/dms.dnp.dappnode.eth) thanks to the amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana)",
   "type": "service",
-  "architectures": ["linux/amd64","linux/arm64"],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "mainService": "validator",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v1.0.4
+        UPSTREAM_VERSION: v1.0.5
     volumes:
       - "beacon-chain-data:/data"
     ports:


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.4 to [v1.0.5](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.5)